### PR TITLE
Disable diff's mnemonicprefix option

### DIFF
--- a/git_crecord/crecord_core.py
+++ b/git_crecord/crecord_core.py
@@ -35,7 +35,7 @@ def dorecord(ui, repo, commitfunc, *pats, **opts):
         left in place, so the user can continue his work.
         """
 
-        git_args = ["git", "diff", "--binary"]
+        git_args = ["git", "-c", "diff.mnemonicprefix=false", "diff", "--binary"]
         git_base = []
 
         if opts['cached']:


### PR DESCRIPTION
With mnemonicprefix enabled the diff output parsing fails.  This is just the simplest fix I could think of, other options might include changing the parser to be more generic.

You could question the value of enabling mnemonicprefix, but I just prefer the output ;)

Thanks,

James