### PR TITLE
Disable Git's `core.quotePath` to fix usage with non-ASCII filenames.

### DIFF
--- a/git_crecord/crecord_core.py
+++ b/git_crecord/crecord_core.py
@@ -33,9 +33,16 @@ def dorecord(ui, repo, commitfunc, *pats, **opts):
 
         In the end we'll record interesting changes, and everything else will be
         left in place, so the user can continue his work.
+
+        Disable `core.quotePath` to support non-ASCII filenames.
+        By default (with `core.quotePath=true`) `git diff` only shows filename characters printable in ASCII,
+        and the presence of any character higher than U+007F will cause `git diff`'s output to double-quote
+        the filename and replace the non-ASCII characters in that filename with their octal representations.
+        The double-quoting (i.e. `diff --git "a/` instead of `diff --git a/`) breaks `crecord`'s stdout parsing.
+        https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
         """
 
-        git_args = ["git", "-c", "diff.mnemonicprefix=false", "diff", "--binary"]
+        git_args = ["git", "-c", "core.quotepath=false", "-c", "diff.mnemonicprefix=false", "diff", "--binary"]
         git_base = []
 
         if opts['cached']:


### PR DESCRIPTION
Git's default configuration causes non-ASCII filename characters to be escaped
in git subcommand stdout, breaking `git-crecord`'s parsing. In my case I don't have the option to just rename the file to an ASCII-compatible filename, because it's a test fixture for a file-type identification library where the filename is significant.

Before, when running `crecord` in my repository with an untracked non-ASCI-named file:

```
[okeeblow@emi#CHECKING YOU OUT] git config core.quotepath on 
[okeeblow@emi#CHECKING YOU OUT] git crecord                 
Traceback (most recent call last):
  File "/home/okeeblow/.local/bin/git-crecord", line 4, in <module>
    main()
  File "/home/okeeblow/Works/git-crecord/git_crecord/main.py", line 203, in main
    crecord_core.dorecord(ui, repo, None, **(opts))
  File "/home/okeeblow/Works/git-crecord/git_crecord/crecord_core.py", line 195, in dorecord
    return recordfunc(ui, repo, "", None, opts)
  File "/home/okeeblow/Works/git-crecord/git_crecord/crecord_core.py", line 54, in recordfunc
    chunks = crpatch.parsepatch(fp)
  File "/home/okeeblow/Works/git-crecord/git_crecord/crpatch.py", line 665, in parsepatch
    for newstate, data in scanpatch(fp):
  File "/home/okeeblow/Works/git-crecord/git_crecord/crpatch.py", line 77, in scanpatch
    raise PatchError('unknown patch content: %r' % line)
git_crecord.crpatch.PatchError: unknown patch content: 'diff --git "a/CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-roxio-toast/Toast 5.0.2 CHECKING YOU OUT\\342\\200\\242image" "b/CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-roxio-toast/Toast 5.0.2 CHECKING YOU OUT\\342\\200\\242image"\n'
```

I recreated the subprocess command used by `crecord`, and here is an example of the double-quoted `diff --git "a/` line that's tripping it up:
```
diff --git "a/CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-roxio-toast/Toast 5.0.2 CHECKING YOU OUT\342\200\242image" "b/CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-roxio-toast/Toast 5.0.2 CHECKING YOU OUT\342\200\242image"
new file mode 100644
index 0000000000000000000000000000000000000000..2d59d302429c26160a1a31beb6a8d6e3e5ade577
GIT binary patch
literal 1067008
zcmeFa2V4{1zUVutl!!nSumWNs5(HFA6zPH#BP}6_)X+sBbfhRn5F#i=ic+J15Q+*2
z2nsf;<&RV&A_$5=L=X)fawq(E`R~0?+4r4y-@fmhEIyN2Gg(vCcm3L0vnJ@8K>+~Z
```

After this patch, where `git-crecord` works as expected:
```
Select hunks to commit - [x]=selected **=collapsed  c: confirm  q: abort  arrow keys: move/expand/collapse  space: deselect  ?: help
[x]**A CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/mac-compactpro/CYO.cpt
[x]**A CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/mac-compactpro/CYO.sea
[x]**A CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-appleworks-document/CYO.cwk
[x]**A CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-roxio-toast/Toast 5.0.2 CHECKING YOU OUT•image
[x]**A CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-stuffit/CYO.sit
[x]**A CHECKING YOU OUT/TEST MY BEST/Try 2 Luv. U/application/x-stuffitx/CHECKING YOU OUT.sitx
```