### PR TITLE
Synchronise lines in hunks when only selecting some of the hunk lines

### DIFF
--- a/git_crecord/crpatch.py
+++ b/git_crecord/crpatch.py
@@ -1034,9 +1034,8 @@ def filterpatch(opts, patch: PatchRoot, chunkselector, ui):
     @@ -1,3 +1,3 @@
      RUN apt-get update
     - && apt-get install -y supervisor python3.8
-         git python3-pip ssl-cert
     + && apt-get install -y supervisor python3.9
-         git python3-pip ssl-cert time
+         git python3-pip ssl-cert
     """
     # if there are no changed files
     if len(patch) == 0:

--- a/git_crecord/crpatch.py
+++ b/git_crecord/crpatch.py
@@ -1040,51 +1040,6 @@ def filterpatch(opts, patch: PatchRoot, chunkselector, ui):
      15
      16
      17
-    >>> rawpatch = b'''diff --git a/Dockerfile b/Dockerfile
-    ... index 00083f466d4f..400252a22712 100644
-    ... --- a/Dockerfile
-    ... +++ b/Dockerfile
-    ... @@ -1,3 +1,3 @@
-    ...  RUN apt-get update
-    ... - && apt-get install -y supervisor python3.8
-    ... -    git python3-pip ssl-cert
-    ... + && apt-get install -y supervisor python3.9
-    ... +    git python3-pip ssl-cert time
-    ... '''
-    >>> patch = parsepatch(io.BytesIO(rawpatch))
-    >>> patch
-    [<header b'Dockerfile' b'Dockerfile'>,
-     <hunk b'Dockerfile'@1>]
-    >>> selections = [True, False, True, False]
-    >>> applied = filterpatch(None, patch, partial(line_selector, selections), None)
-    >>> print(applied.headers[0].hunks[0].changedlines)
-    [<hunkline/-/1 [x] b' && apt-g'>,
-     <hunkline/-/2 [ ] b'    git p'>,
-     <hunkline/+/1 [x] b' && apt-g'>,
-     <hunkline/+/2 [ ] b'    git p'>]
-    >>> print(applied.hunks[0])
-    @@ -1,3 +1,3 @@
-     RUN apt-get update
-    - && apt-get install -y supervisor python3.8
-    + && apt-get install -y supervisor python3.9
-         git python3-pip ssl-cert
-    >>> selections = [True, True, True, False]
-    >>> applied = filterpatch(None, patch, partial(line_selector, selections), None)
-    >>> print(applied.hunks[0])
-    @@ -1,3 +1,2 @@
-     RUN apt-get update
-    - && apt-get install -y supervisor python3.8
-    + && apt-get install -y supervisor python3.9
-    -    git python3-pip ssl-cert
-    >>> selections = [True, False, True, True]
-    >>> applied = filterpatch(None, patch, partial(line_selector, selections), None)
-    >>> print(applied.hunks[0])
-    @@ -1,3 +1,4 @@
-     RUN apt-get update
-    - && apt-get install -y supervisor python3.8
-    + && apt-get install -y supervisor python3.9
-         git python3-pip ssl-cert
-    +    git python3-pip ssl-cert time
     """
     # if there are no changed files
     if len(patch) == 0:

--- a/tests/test_hunk_splitting.py
+++ b/tests/test_hunk_splitting.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import io
+from collections.abc import Sequence
+from functools import partial
+from textwrap import dedent
+
+import pytest
+
+from git_crecord.crpatch import filterpatch, parsepatch
+
+
+def line_selector(selections: Sequence[bool], opts, headers, ui):
+    for i, hunkline in enumerate(headers[0].hunks[0].changedlines):
+        hunkline.applied = selections[i]
+
+
+@pytest.mark.parametrize(
+    "selections, expected",
+    [
+        pytest.param(
+            [True, False, True, False],
+            '''
+            @@ -1,3 +1,3 @@
+             RUN apt-get update
+            - && apt-get install -y supervisor python3.8
+            + && apt-get install -y supervisor python3.9
+                 git python3-pip ssl-cert
+            ''',
+            id="symmetric",
+        ),
+        pytest.param(
+            [True, True, True, False],
+            '''
+            @@ -1,3 +1,2 @@
+             RUN apt-get update
+            - && apt-get install -y supervisor python3.8
+            + && apt-get install -y supervisor python3.9
+            -    git python3-pip ssl-cert
+            ''',
+            id="extra deletion",
+        ),
+        pytest.param(
+            [True, False, True, True],
+            '''
+            @@ -1,3 +1,4 @@
+             RUN apt-get update
+            - && apt-get install -y supervisor python3.8
+            + && apt-get install -y supervisor python3.9
+                 git python3-pip ssl-cert
+            +    git python3-pip ssl-cert time
+            ''',
+            id="extra addition",
+        ),
+    ]
+)
+def test_hunk_splitting(selections: Sequence[bool], expected: str):
+    diff = dedent(
+        '''
+        diff --git a/Dockerfile b/Dockerfile
+        index 00083f466d4f..400252a22712 100644
+        --- a/Dockerfile
+        +++ b/Dockerfile
+        @@ -1,3 +1,3 @@
+         RUN apt-get update
+        - && apt-get install -y supervisor python3.8
+        -    git python3-pip ssl-cert
+        + && apt-get install -y supervisor python3.9
+        +    git python3-pip ssl-cert time
+        '''
+    ).lstrip('\n').encode()
+    patch = parsepatch(io.BytesIO(diff))
+    applied = filterpatch(None, patch, partial(line_selector, selections), None)
+
+    assert str(applied.hunks[0]) == dedent(expected).lstrip('\n')


### PR DESCRIPTION
Sort the lines in hunks by their original offset, skip unapplied additions

Committing one change but not the other:

            @@ -1,3 +1,3 @@
             RUN apt-get update
       [x]  - && apt-get install -y supervisor python3.8
       [ ]  -    git python3-pip ssl-cert
       [x]  + && apt-get install -y supervisor python3.9
       [ ]  +    git python3-pip ssl-cert time

Most users would expect this diff:
```diff
@@ -1,3 +1,3 @@
 RUN apt-get update
- && apt-get install -y supervisor python3.8
+ && apt-get install -y supervisor python3.9
     git python3-pip ssl-cert
```

Currently produces:
```diff
@@ -1,3 +1,3 @@
 RUN apt-get update
-    git python3-pip ssl-cert
  && apt-get install -y supervisor python3.9
+    git python3-pip ssl-cert time
```

Committing all deletions but not all additions:

            @@ -1,3 +1,3 @@
             RUN apt-get update
       [x]  - && apt-get install -y supervisor python3.8
       [x]  -    git python3-pip ssl-cert
       [x]  + && apt-get install -y supervisor python3.9
       [ ]  +    git python3-pip ssl-cert time

This case is clear, too:
```diff
@@ -1,3 +1,2 @@
 RUN apt-get update
- && apt-get install -y supervisor python3.8
+ && apt-get install -y supervisor python3.9
-    git python3-pip ssl-cert
```

Committing all additions but not all deletions:

            @@ -1,3 +1,3 @@
             RUN apt-get update
       [x]  - && apt-get install -y supervisor python3.8
       [ ]  -    git python3-pip ssl-cert
       [x]  + && apt-get install -y supervisor python3.9
       [x]  +    git python3-pip ssl-cert time

What to do in this case? Could be this, but it does not make much sense:
```diff
@@ -1,3 +1,2 @@
 RUN apt-get update
- && apt-get install -y supervisor python3.8
+ && apt-get install -y supervisor python3.9
+    git python3-pip ssl-cert time
     git python3-pip ssl-cert
```

This is more consistent and easier to implement by sorting the original lines before the new ones:
```diff
@@ -1,3 +1,4 @@
 RUN apt-get update
- && apt-get install -y supervisor python3.8
+ && apt-get install -y supervisor python3.9
     git python3-pip ssl-cert
+    git python3-pip ssl-cert time
```

This will fix #29.