### PR TITLE
Hunkline noeol fix

### DIFF
--- a/git_crecord/crpatch.py
+++ b/git_crecord/crpatch.py
@@ -624,7 +624,7 @@ class Hunk(PatchNode):
                 line.offset = toline
             if line.diffop == HunkLine.NOEOL:
                 if not deletes:
-                    line.offset = fromtoline
+                    line.offset = fromline
                 else:
                     line.offset = toline
 

--- a/git_crecord/crpatch.py
+++ b/git_crecord/crpatch.py
@@ -135,6 +135,8 @@ def scanpatch(fp: IO[bytes]):
             yield 'hunk', scanwhile(line, lambda l: l[0] in b'-+\\')
         elif line.startswith(b'* Unmerged path '):
             continue
+        elif line.startswith(b'\\ No newline at end of file'):
+            continue
         else:
             m = lines_re.match(line)
             if m:


### PR DESCRIPTION
This PR fixes a basic typo in `HunkLine.NOEOL` handling if `Hunk.countoffsets()`.  

This typo resulted in the following traceback:
```
$ ~/gcode/git-crecord/git-crecord
Traceback (most recent call last):
  File "/home/russ/gcode/git-crecord/git-crecord", line 4, in <module>
    main()
  File "/home/russ/gcode/git-crecord/git_crecord/main.py", line 254, in main
    crecord_core.dorecord(ui, repo, **opts)
  File "/home/russ/gcode/git-crecord/git_crecord/crecord_core.py", line 75, in dorecord
    chunks = parsepatch(fp)
             ^^^^^^^^^^^^^^
  File "/home/russ/gcode/git-crecord/git_crecord/crpatch.py", line 1044, in parsepatch
    return PatchRoot(p.finished())
                     ^^^^^^^^^^^^
  File "/home/russ/gcode/git-crecord/git_crecord/crpatch.py", line 1004, in finished
    self.add_new_hunk()
  File "/home/russ/gcode/git-crecord/git_crecord/crpatch.py", line 937, in add_new_hunk
    h = Hunk(
        ^^^^^
  File "/home/russ/gcode/git-crecord/git_crecord/crpatch.py", line 549, in __init__
    self.countoffsets()
  File "/home/russ/gcode/git-crecord/git_crecord/crpatch.py", line 627, in countoffsets
    line.offset = fromtoline
                  ^^^^^^^^^^
NameError: name 'fromtoline' is not defined. Did you mean: 'fromline'?
```